### PR TITLE
Rename springboard_linux_amd64 in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ tracking and publishing the sensitive data needed to run your applications.
 	wget http://dl.fligl.io/artifacts/springboard/springboard_linux_amd64.gz
 	gunzip springboard_linux_amd64.gz
 	chmod +x springboard_linux_amd64
-	mv springboard_linux_amd64 /usr/local/bin/
+	mv springboard_linux_amd64 /usr/local/bin/springboard
 
 ## Configure Vault
 


### PR DESCRIPTION
The README refers to springboard as springboard in latter parts of the document. Therefore, modify the install to rename springboard_linux_amd64 to springboard as part of the mv command.