### PR TITLE
enabling removal of a single key from vault and the yml file

### DIFF
--- a/app.go
+++ b/app.go
@@ -48,6 +48,13 @@ func (a *App) set(key string, value string) error {
 	return a.secrets.Save()
 }
 
+func (a *App) remove(key string) error {
+	if err := a.secrets.Remove(key); err != nil {
+		return err
+	}
+	return a.secrets.Save()
+}
+
 func (a *App) push(path string) error {
 	pub := publisher.New(a.vault, path)
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ func usage() {
 	fmt.Printf("    help                display this help screen and exit\n")
 	fmt.Printf("    set <key> <value>   set/encrypt 'value' in local secrets file\n")
 	fmt.Printf("    get <key>           get/decrypt 'value' from local secrets file\n")
+	fmt.Printf("    remove <key>        remove 'key' (and its value) from local secrets file\n")
 	fmt.Printf("    push <path>         publish secrets in local secrets file to\n")
 	fmt.Printf("                        'path' in vault generic secrets backend\n\n")
 
@@ -23,6 +24,7 @@ func usage() {
 	fmt.Printf("Examples:\n")
 	fmt.Printf("    springboard set -s secrets.yml -t my-key user_name supersecret\n")
 	fmt.Printf("    springboard get -s secrets.yml -t my-key user_name\n")
+	fmt.Printf("    springboard remove -s secrets.yml -t my-key user_name\n")
 	fmt.Printf("    springboard push -s secrets.yml -t my-key secret/my-space\n\n")
 
 	fmt.Printf("github.com/benschw/springboard\n")
@@ -74,6 +76,15 @@ func main() {
 			os.Exit(2)
 		}
 		if err := app.set(args[0], args[1]); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	case "remove":
+		if len(args) != 1 {
+			f.Usage()
+			os.Exit(2)
+		}
+		if err := app.remove(args[0]); err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -45,6 +45,7 @@ func (s *Secrets) Keys() []string {
 	}
 	return keys
 }
+
 func (s *Secrets) Set(key string, value string) error {
 	val, err := s.crypt.Encrypt(value)
 	if err != nil {
@@ -59,6 +60,18 @@ func (s *Secrets) Set(key string, value string) error {
 	s.data = append(s.data, SecretsEntry{Key: key, Value: val})
 	return nil
 }
+
+func (s *Secrets) Remove(key string) error {
+	for i := 0; i < len(s.data); i++ {
+		if s.data[i].Key == key {
+			//remove the element
+			s.data = append(s.data[:i], s.data[i+1:]...)
+			return nil
+		}
+	}
+	return errors.New("key not found")
+}
+
 func (s *Secrets) Get(key string) (string, error) {
 	for i := 0; i < len(s.data); i++ {
 		if s.data[i].Key == key {

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -58,6 +58,32 @@ func TestSecretStorage(t *testing.T) {
 		t.Error("should equal bar", val)
 	}
 }
+
+func TestSecretRemove(t *testing.T) {
+	file, _ := ioutil.TempFile(os.TempDir(), "vault")
+	defer os.Remove(file.Name())
+
+	s, _ := New(file.Name(), &stubCrypt{})
+
+	s.Set("foo", "bar")
+	if err := s.Save(); err != nil {
+		t.Error("problem saving", err)
+	}
+
+	s.Remove("foo")
+	if err := s.Save(); err != nil {
+		t.Error("problem saving", err)
+	}
+
+	s2, _ := New(file.Name(), &stubCrypt{})
+
+	val, err := s2.Get("foo")
+
+	if err == nil {
+		t.Error("should have been removed", val)
+	}
+}
+
 func TestKeys(t *testing.T) {
 	file, _ := ioutil.TempFile(os.TempDir(), "vault")
 	defer os.Remove(file.Name())


### PR DESCRIPTION
This tool/library is pretty cool for tracking and adding new secrets, but it's missing a remove. Added in the removal function.